### PR TITLE
Add Game Over overlay with retry button

### DIFF
--- a/app.js
+++ b/app.js
@@ -60,6 +60,7 @@
   const downloadCsvBtn=document.getElementById('downloadCsv'); const fsBtn=document.getElementById('fsBtn');
   const difficultySel=document.getElementById('difficulty'), themePlaySel=document.getElementById('themePlay');
   const replayBtn=document.getElementById('replayBtn');
+  const tryAgainBtn=document.getElementById('tryAgainBtn');
   const W=canvas.width, H=canvas.height;
 
   let state={ running:false, paused:false, over:false,
@@ -127,6 +128,7 @@
     const base=getBankFor(bankKey);
     if(!base.length){ notice('Ce thème ne contient aucune question.', 'var(--danger)'); overlay.hidden=false; return; }
     overlay.hidden=true; state.running=true; state.paused=false; state.over=false;
+    overlayStart.hidden=true; tryAgainBtn.hidden=true; downloadCsvBtn.hidden=true;
     state.score=0; state.lives=3; state.timeLeft=120; state.stats=[]; setLivesIcons();
     state.player.x=W/2; state.bullets=[]; state.enemyBullets=[]; state.enemies=[]; state.qIndex=0; state.shields=[]; state.bonuses=[]; notice('');
     state.totalCorrect=0; state.correctSinceSizeToggle=0; state.aliensBuffed=false; state.shieldSmall=false; state.player.sizeFactor=1;
@@ -140,7 +142,12 @@
   function endGame(){
     state.running=false; state.over=true; overlay.hidden=false; downloadCsvBtn.hidden=false;
     const ok=state.stats.filter(s=>s.ok).length, total=state.stats.length||1, rate=Math.round(100*ok/total);
-    overlay.querySelector('h2').textContent=`Partie terminée — Score : ${state.score} — Réussite : ${rate}% — Record de série : ${state.bestStreak}`;
+    const h2=overlay.querySelector('h2');
+    h2.textContent='Game Over';
+    h2.classList.add('pixel-font');
+    const p=overlay.querySelector('p');
+    if(p){ p.textContent=`Score : ${state.score} — Réussite : ${rate}% — Record de série : ${state.bestStreak}`; }
+    overlayStart.hidden=true; tryAgainBtn.hidden=false;
   }
 
   let QUESTION_BANK=[];
@@ -291,7 +298,7 @@
   }
   applyDifficulty();
 
-  overlayStart.onclick=startGame; startBtn.onclick=startGame; replayBtn.onclick=startGame;
+  overlayStart.onclick=startGame; startBtn.onclick=startGame; replayBtn.onclick=startGame; tryAgainBtn.onclick=startGame;
   pauseBtn.onclick=togglePause; fsBtn.onclick=toggleFullscreen; downloadCsvBtn.onclick=exportCSV;
   difficultySel.onchange=applyDifficulty; themePlaySel.onchange=themeChanged;
 

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Quiz Invaders BTP — Arcade (QCM)</title>
   <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
 </head>
 <body>
   <header class="marquee">
@@ -58,6 +59,7 @@
                les erreurs retirent une vie et les ennemis bombardent davantage.</p>
             <div class="row" style="gap:10px">
               <button class="primary" id="overlayStart">Lancer la partie</button>
+              <button class="pixel-btn" id="tryAgainBtn" hidden>Try again</button>
               <button class="ghost" id="downloadCsv" hidden>Télécharger les résultats (.csv)</button>
             </div>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -71,3 +71,22 @@ footer .tip{ text-align:center; margin:12px 0 22px; }
   z-index: 50;
   pointer-events: none;
 }
+
+.pixel-font{
+  font-family:'Press Start 2P',monospace;
+}
+
+.pixel-btn{
+  font-family:'Press Start 2P',monospace;
+  background:#0d1340;
+  color:#fff;
+  border:4px solid #66d8ff;
+  padding:12px 20px;
+  text-transform:uppercase;
+  box-shadow:0 4px 0 #000;
+}
+
+.pixel-btn:active{
+  box-shadow:none;
+  transform:translateY(4px);
+}


### PR DESCRIPTION
## Summary
- Show pixel-font **Game Over** heading with a retry button on game end
- Add pixel-art styling and Google font import
- Reset state and bind the new **Try again** button to restart gameplay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ca94a704c8326b03f52e78d7b8a70