### PR TITLE
Remove redundant start controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,10 +56,9 @@
   const timeEl=document.getElementById('time'), questionTextEl=document.getElementById('questionText');
   const choicesChipsEl=document.getElementById('choicesChips'), noticeEl=document.getElementById('notice');
   const overlay=document.getElementById('overlay'); const overlayStart=document.getElementById('overlayStart');
-  const startBtn=document.getElementById('startBtn'); const pauseBtn=document.getElementById('pauseBtn');
+  const pauseBtn=document.getElementById('pauseBtn');
   const downloadCsvBtn=document.getElementById('downloadCsv'); const fsBtn=document.getElementById('fsBtn');
   const difficultySel=document.getElementById('difficulty'), themePlaySel=document.getElementById('themePlay');
-  const replayBtn=document.getElementById('replayBtn');
   const W=canvas.width, H=canvas.height;
 
   let state={ running:false, paused:false, over:false,
@@ -291,7 +290,7 @@
   }
   applyDifficulty();
 
-  overlayStart.onclick=startGame; startBtn.onclick=startGame; replayBtn.onclick=startGame;
+  overlayStart.onclick=startGame;
   pauseBtn.onclick=togglePause; fsBtn.onclick=toggleFullscreen; downloadCsvBtn.onclick=exportCSV;
   difficultySel.onchange=applyDifficulty; themePlaySel.onchange=themeChanged;
 

--- a/index.html
+++ b/index.html
@@ -25,7 +25,6 @@
 
       <label class="sound"><input id="sound" type="checkbox" /> Son</label>
 
-      <button id="startBtn" class="primary">Démarrer ⏎</button>
       <button id="pauseBtn" class="ghost" title="P">Pause</button>
       <button id="fsBtn" class="ghost" title="F">Plein écran (F)</button>
     </div>
@@ -68,7 +67,6 @@
         <div id="qa">
           <div id="questionText">Chargement des questions…</div>
           <div id="choicesChips"></div>
-          <button id="replayBtn" class="ghost" style="margin-top:8px">Rejouer</button>
           <p class="hint">Visez la lettre sous l’invader (A/B/C).</p>
         </div>
       </aside>


### PR DESCRIPTION
## Summary
- Drop unused start and replay buttons from markup
- Clean up related variables and events in script
- Ensure Enter key still starts the game

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ca94b962c8326ad564ee69e49d119